### PR TITLE
Add all event types

### DIFF
--- a/lib/events/ack.js
+++ b/lib/events/ack.js
@@ -1,5 +1,5 @@
 'use strict'
 
-module.exports = evtId => ({
+module.exports = ({ evtId }) => ({
   ack: { 'evt-id': evtId },
 })

--- a/lib/events/client/auth.js
+++ b/lib/events/client/auth.js
@@ -8,7 +8,7 @@ const shortid = require('shortid')
  * @return {Object} event
  */
 
-const auth = token => ({
+const auth = ({ token }) => ({
   auth: {
     'evt-id': shortid(),
     token,

--- a/lib/events/client/auth.js
+++ b/lib/events/client/auth.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const shortid = require('shortid')
+
+/**
+ * Creates an autharization protocol event
+ * @param {string} token authorization token
+ * @return {Object} event
+ */
+
+const auth = token => ({
+  auth: {
+    'evt-id': shortid(),
+    token,
+  },
+})
+
+module.exports = auth

--- a/lib/events/client/con.js
+++ b/lib/events/client/con.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const shortid = require('shortid')
+
+/**
+ * Creates a connect protocol event
+ * @param {String} conId connection id
+ * @return {Object} event
+ */
+
+const con = conId => ({
+  con: {
+    'evt-id': shortid(),
+    'con-id': conId,
+  },
+})
+
+module.exports = con

--- a/lib/events/client/con.js
+++ b/lib/events/client/con.js
@@ -8,7 +8,7 @@ const shortid = require('shortid')
  * @return {Object} event
  */
 
-const con = conId => ({
+const con = ({ conId }) => ({
   con: {
     'evt-id': shortid(),
     'con-id': conId,

--- a/lib/events/client/deauth.js
+++ b/lib/events/client/deauth.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const shortid = require('shortid')
+
+/**
+ * Creates an deauthorization protocol event
+ * @return {Object} event
+ */
+
+const deauth = () => ({
+  deauth: {
+    'evt-id': shortid(),
+  },
+})
+
+module.exports = deauth

--- a/lib/events/client/del.js
+++ b/lib/events/client/del.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const shortid = require('shortid')
+
+/**
+ * Creates a delete protocol event
+ * @param {string} colId collection id
+ * @param {string} docId documend id
+ * @return {Object} event
+ */
+
+const del = (colId, docId, etag) => ({
+  del: {
+    'evt-id': shortid(),
+    'col-id': colId,
+    doc: {
+      id: docId,
+      etag,
+    },
+  },
+})
+
+module.exports = del

--- a/lib/events/client/del.js
+++ b/lib/events/client/del.js
@@ -4,12 +4,14 @@ const shortid = require('shortid')
 
 /**
  * Creates a delete protocol event
- * @param {string} colId collection id
- * @param {string} docId documend id
+ * @param {Object} del
+ * @param {String} del.colId - collection id
+ * @param {String} del.docId - documend id
+ * @param {String=} del.etag - documend id
  * @return {Object} event
  */
 
-const del = (colId, docId, etag) => ({
+const del = ({ colId, docId, etag = undefined }) => ({
   del: {
     'evt-id': shortid(),
     'col-id': colId,

--- a/lib/events/client/dis.js
+++ b/lib/events/client/dis.js
@@ -1,0 +1,12 @@
+'use strict'
+
+/**
+ * Creates a disconnect protocol event
+ * @return {Object} event
+ */
+
+const dis = () => ({
+  dis: null,
+})
+
+module.exports = dis

--- a/lib/events/client/ftc.js
+++ b/lib/events/client/ftc.js
@@ -4,16 +4,16 @@ const shortid = require('shortid')
 
 /**
  * Creates a fetch protocol event
- * @param {string} ftc fetch id
- * @param {string} colId collection id
+ * @param {String} ftc fetch id
+ * @param {String} colId collection id
  * @param {object=} query query object
  * @return {Object} event
  */
 
-const ftc = (colId, { filter, order, limit, skip }) => ({
+const ftc = ({ colId, ftcId, query: { filter, order, limit, skip } = {} }) => ({
   ftc: {
     'evt-id': shortid(),
-    'ftc-id': shortid(),
+    'ftc-id': ftcId,
     'col-id': colId,
     filter,
     order: order && [order],

--- a/lib/events/client/ftc.js
+++ b/lib/events/client/ftc.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const shortid = require('shortid')
+
+/**
+ * Creates a fetch protocol event
+ * @param {string} ftc fetch id
+ * @param {string} colId collection id
+ * @param {object=} query query object
+ * @return {Object} event
+ */
+
+const ftc = (colId, { filter, order, limit, skip }) => ({
+  ftc: {
+    'evt-id': shortid(),
+    'ftc-id': shortid(),
+    'col-id': colId,
+    filter,
+    order: order && [order],
+    limit,
+    skip,
+  },
+})
+
+module.exports = ftc

--- a/lib/events/client/index.js
+++ b/lib/events/client/index.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const ack = require('./ack')
+const con = require('./con')
+const rec = require('./rec')
+const dis = require('./dis')
+const mut = require('./mut')
+const mer = require('./mer')
+const del = require('./del')
+const ftc = require('./ftc')
+const sub = require('./sub')
+const uns = require('./uns')
+const auth = require('./auth')
+const deauth = require('./deauth')
+const nop = require('./nop')
+
+module.exports = {
+  ack,
+  con,
+  rec,
+  dis,
+  mut,
+  mer,
+  del,
+  ftc,
+  sub,
+  uns,
+  auth,
+  deauth,
+  nop,
+}

--- a/lib/events/client/mer.js
+++ b/lib/events/client/mer.js
@@ -10,7 +10,7 @@ const shortid = require('shortid')
  * @return {Object} event
  */
 
-const mer = (colId, docId, body, etag) => ({
+const mer = ({ colId, docId, body, etag = undefined }) => ({
   mer: {
     'evt-id': shortid(),
     'col-id': colId,

--- a/lib/events/client/mer.js
+++ b/lib/events/client/mer.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const shortid = require('shortid')
+
+/**
+ * Creates a merge protocol event
+ * @param {String} colId collection id
+ * @param {String} docId documend id
+ * @param {Object} body properties to merge
+ * @return {Object} event
+ */
+
+const mer = (colId, docId, body, etag) => ({
+  mer: {
+    'evt-id': shortid(),
+    'col-id': colId,
+    doc: {
+      id: docId,
+      etag,
+      body,
+    },
+  },
+})
+
+module.exports = mer

--- a/lib/events/client/mut.js
+++ b/lib/events/client/mut.js
@@ -10,7 +10,7 @@ const shortid = require('shortid')
  * @return {Object} event
  */
 
-const mut = (colId, docId, body, etag) => ({
+const mut = ({ colId, docId, body, etag = undefined }) => ({
   mut: {
     'evt-id': shortid(),
     'col-id': colId,

--- a/lib/events/client/mut.js
+++ b/lib/events/client/mut.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const shortid = require('shortid')
+
+/**
+ *
+ * @param {string} colId collection ID
+ * @param {string} docId document ID
+ * @param {object} body properties to mutate
+ * @return {Object} event
+ */
+
+const mut = (colId, docId, body, etag) => ({
+  mut: {
+    'evt-id': shortid(),
+    'col-id': colId,
+    doc: {
+      id: docId,
+      etag,
+      body,
+    },
+  },
+})
+
+module.exports = mut

--- a/lib/events/client/nop.js
+++ b/lib/events/client/nop.js
@@ -1,0 +1,12 @@
+'use strict'
+
+/**
+ * No operation event
+ * @return {Object} event
+ */
+
+const nop = () => ({
+  nop: null,
+})
+
+module.exports = nop

--- a/lib/events/client/pub.js
+++ b/lib/events/client/pub.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const shortid = require('shortid')
+
+/**
+ * Creates publish event
+ * @param {String} chanId channel id
+ * @param {Object} body channel message
+ */
+const pub = (chanId, body) => ({
+  'evt-id': shortid(),
+  'chan-id': chanId,
+  body,
+})
+
+module.exports = pub

--- a/lib/events/client/pub.js
+++ b/lib/events/client/pub.js
@@ -8,9 +8,11 @@ const shortid = require('shortid')
  * @param {Object} body channel message
  */
 const pub = (chanId, body) => ({
-  'evt-id': shortid(),
-  'chan-id': chanId,
-  body,
+  pub: {
+    'evt-id': shortid(),
+    'chan-id': chanId,
+    body,
+  },
 })
 
 module.exports = pub

--- a/lib/events/client/pub.js
+++ b/lib/events/client/pub.js
@@ -7,7 +7,7 @@ const shortid = require('shortid')
  * @param {(String|Object)} chanId channel id
  * @param {Object} body channel message
  */
-const pub = (chanId, body) => ({
+const pub = ({ chanId, body }) => ({
   pub: {
     'evt-id': shortid(),
     'chan-id': chanId,

--- a/lib/events/client/pub.js
+++ b/lib/events/client/pub.js
@@ -4,7 +4,7 @@ const shortid = require('shortid')
 
 /**
  * Creates publish event
- * @param {String} chanId channel id
+ * @param {(String|Object)} chanId channel id
  * @param {Object} body channel message
  */
 const pub = (chanId, body) => ({

--- a/lib/events/client/rec.js
+++ b/lib/events/client/rec.js
@@ -8,7 +8,7 @@ const shortid = require('shortid')
  * @return {Object} event
  */
 
-const rec = conId => ({
+const rec = ({ conId }) => ({
   rec: {
     'evt-id': shortid(),
     'con-id': conId,

--- a/lib/events/client/rec.js
+++ b/lib/events/client/rec.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const shortid = require('shortid')
+
+/**
+ * Creates a reconnect protocol event
+ * @param {string} conId connection id
+ * @return {Object} event
+ */
+
+const rec = conId => ({
+  rec: {
+    'evt-id': shortid(),
+    'con-id': conId,
+  },
+})
+
+module.exports = rec

--- a/lib/events/client/sub-ch.js
+++ b/lib/events/client/sub-ch.js
@@ -8,9 +8,11 @@ const shortid = require('shortid')
  * @param {String} subId subscription id
  */
 const subCh = (chanId, subId) => ({
-  'evt-id': shortid(),
-  'chan-id': chanId,
-  'sub-id': subId,
+  'sub-ch': {
+    'evt-id': shortid(),
+    'chan-id': chanId,
+    'sub-id': subId,
+  },
 })
 
 module.exports = subCh

--- a/lib/events/client/sub-ch.js
+++ b/lib/events/client/sub-ch.js
@@ -7,7 +7,7 @@ const shortid = require('shortid')
  * @param {(String|Object)} chanId channel id
  * @param {String} subId subscription id
  */
-const subCh = (chanId, subId) => ({
+const subCh = ({ chanId, subId }) => ({
   'sub-ch': {
     'evt-id': shortid(),
     'chan-id': chanId,

--- a/lib/events/client/sub-ch.js
+++ b/lib/events/client/sub-ch.js
@@ -4,7 +4,7 @@ const shortid = require('shortid')
 
 /**
  * Create channel subscription event
- * @param {String} chanId channel id
+ * @param {(String|Object)} chanId channel id
  * @param {String} subId subscription id
  */
 const subCh = (chanId, subId) => ({

--- a/lib/events/client/sub-ch.js
+++ b/lib/events/client/sub-ch.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const shortid = require('shortid')
+
+/**
+ * Create channel subscription event
+ * @param {String} chanId channel id
+ * @param {String} subId subscription id
+ */
+const subCh = (chanId, subId) => ({
+  'evt-id': shortid(),
+  'chan-id': chanId,
+  'sub-id': subId,
+})
+
+module.exports = subCh

--- a/lib/events/client/sub.js
+++ b/lib/events/client/sub.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const shortid = require('shortid')
+
+/**
+ * Creates a subscription protocol event
+ * @param {string} subId subscription id
+ * @param {string} colId collection id
+ * @param {object=} query query object
+ * @return {Object} event
+ */
+
+const sub = (subId, colId, { filter, order, limit, skip }) => ({
+  sub: {
+    'evt-id': shortid(),
+    'sub-id': subId,
+    'col-id': colId,
+    filter,
+    order: order && [order],
+    limit,
+    skip,
+  },
+})
+
+module.exports = sub

--- a/lib/events/client/sub.js
+++ b/lib/events/client/sub.js
@@ -16,7 +16,7 @@ const sub = (subId, colId, { filter, order, limit, skip }) => ({
     'sub-id': subId,
     'col-id': colId,
     filter,
-    order: order && [order],
+    order: order && [order], // we enforce Object, but server expects array
     limit,
     skip,
   },

--- a/lib/events/client/sub.js
+++ b/lib/events/client/sub.js
@@ -10,7 +10,7 @@ const shortid = require('shortid')
  * @return {Object} event
  */
 
-const sub = (subId, colId, { filter, order, limit, skip }) => ({
+const sub = ({ subId, colId, query: { filter, order, limit, skip } = {} }) => ({
   sub: {
     'evt-id': shortid(),
     'sub-id': subId,

--- a/lib/events/client/uns-ch.js
+++ b/lib/events/client/uns-ch.js
@@ -7,8 +7,10 @@ const shortid = require('shortid')
  * @param {String} subId subscription id
  */
 const unsCh = subId => ({
-  'evt-id': shortid(),
-  'sub-id': subId,
+  'uns-ch': {
+    'evt-id': shortid(),
+    'sub-id': subId,
+  },
 })
 
 module.exports = unsCh

--- a/lib/events/client/uns-ch.js
+++ b/lib/events/client/uns-ch.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const shortid = require('shortid')
+
+/**
+ * Create channel unsubscription event
+ * @param {String} subId subscription id
+ */
+const unsCh = subId => ({
+  'evt-id': shortid(),
+  'sub-id': subId,
+})
+
+module.exports = unsCh

--- a/lib/events/client/uns-ch.js
+++ b/lib/events/client/uns-ch.js
@@ -6,7 +6,7 @@ const shortid = require('shortid')
  * Create channel unsubscription event
  * @param {String} subId subscription id
  */
-const unsCh = subId => ({
+const unsCh = ({ subId }) => ({
   'uns-ch': {
     'evt-id': shortid(),
     'sub-id': subId,

--- a/lib/events/client/uns.js
+++ b/lib/events/client/uns.js
@@ -8,7 +8,7 @@ const shortid = require('shortid')
  * @return {Object} event
  */
 
-const uns = subId => ({
+const uns = ({ subId }) => ({
   uns: {
     'evt-id': shortid(),
     'sub-id': subId,

--- a/lib/events/client/uns.js
+++ b/lib/events/client/uns.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const shortid = require('shortid')
+
+/**
+ * Creates an unsubscribe protocl event
+ * @param {string} subId subscription id
+ * @return {Object} event
+ */
+
+const uns = subId => ({
+  uns: {
+    'evt-id': shortid(),
+    'sub-id': subId,
+  },
+})
+
+module.exports = uns

--- a/lib/events/err.js
+++ b/lib/events/err.js
@@ -1,6 +1,6 @@
 'use strict'
 
-module.exports = (evtId, errType, errMessage) => ({
+module.exports = ({ evtId, errType, errMessage }) => ({
   err: {
     'evt-id': evtId,
     'err-type': errType,

--- a/lib/events/server/ca-ch.js
+++ b/lib/events/server/ca-ch.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const shortid = require('shortid')
+
+/**
+ * Creates cancel-channel event
+ * @param {String} chanId channel id
+ * @param {String} subId subscription id
+ */
+const caCh = (chanId, subId) => ({
+  'evt-id': shortid(),
+  'chan-id': chanId,
+  'sub-id': subId,
+})
+
+module.exports = caCh

--- a/lib/events/server/ca-ch.js
+++ b/lib/events/server/ca-ch.js
@@ -4,7 +4,7 @@ const shortid = require('shortid')
 
 /**
  * Creates cancel-channel event
- * @param {String} chanId channel id
+ * @param {(String|Object)} chanId channel id
  * @param {String} subId subscription id
  */
 const caCh = (chanId, subId) => ({

--- a/lib/events/server/ca-ch.js
+++ b/lib/events/server/ca-ch.js
@@ -8,9 +8,11 @@ const shortid = require('shortid')
  * @param {String} subId subscription id
  */
 const caCh = (chanId, subId) => ({
-  'evt-id': shortid(),
-  'chan-id': chanId,
-  'sub-id': subId,
+  'ca-ch': {
+    'evt-id': shortid(),
+    'chan-id': chanId,
+    'sub-id': subId,
+  },
 })
 
 module.exports = caCh

--- a/lib/events/server/ca-ch.js
+++ b/lib/events/server/ca-ch.js
@@ -7,7 +7,7 @@ const shortid = require('shortid')
  * @param {(String|Object)} chanId channel id
  * @param {String} subId subscription id
  */
-const caCh = (chanId, subId) => ({
+const caCh = ({ chanId, subId }) => ({
   'ca-ch': {
     'evt-id': shortid(),
     'chan-id': chanId,

--- a/lib/events/server/ca.js
+++ b/lib/events/server/ca.js
@@ -8,9 +8,11 @@ const shortid = require('shortid')
  * @param {String} subId subscription id
  */
 const ca = (colId, subId) => ({
-  'evt-id': shortid(),
-  'col-id': colId,
-  'sub-id': subId,
+  ca: {
+    'evt-id': shortid(),
+    'col-id': colId,
+    'sub-id': subId,
+  },
 })
 
 module.exports = ca

--- a/lib/events/server/ca.js
+++ b/lib/events/server/ca.js
@@ -7,7 +7,7 @@ const shortid = require('shortid')
  * @param {String} colId collection id
  * @param {String} subId subscription id
  */
-const ca = (colId, subId) => ({
+const ca = ({ colId, subId }) => ({
   ca: {
     'evt-id': shortid(),
     'col-id': colId,

--- a/lib/events/server/ca.js
+++ b/lib/events/server/ca.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const shortid = require('shortid')
+
+/**
+ * Creates cancel event
+ * @param {String} colId collection id
+ * @param {String} subId subscription id
+ */
+const ca = (colId, subId) => ({
+  'evt-id': shortid(),
+  'col-id': colId,
+  'sub-id': subId,
+})
+
+module.exports = ca

--- a/lib/events/server/index.js
+++ b/lib/events/server/index.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const res = require('./res')
+const val = require('./val')
+const upd = require('./upd')
+const rm = require('./rm')
+const ca = require('./ca')
+const caCh = require('./ca-ch')
+const mes = require('./mes')
+
+module.exports = {
+  res,
+  val,
+  upd,
+  rm,
+  ca,
+  caCh,
+  mes,
+}

--- a/lib/events/server/mes.js
+++ b/lib/events/server/mes.js
@@ -9,10 +9,12 @@ const shortid = require('shortid')
  * @param {Object} body channel message
  */
 const mes = (chanId, subId, body) => ({
-  'evt-id': shortid(),
-  'chan-id': chanId,
-  'sub-id': subId,
-  body,
+  mes: {
+    'evt-id': shortid(),
+    'chan-id': chanId,
+    'sub-id': subId,
+    body,
+  },
 })
 
 module.exports = mes

--- a/lib/events/server/mes.js
+++ b/lib/events/server/mes.js
@@ -4,9 +4,9 @@ const shortid = require('shortid')
 
 /**
  * Creates message event
- * @param {String} chanId channel id
+ * @param {(String|Object)} chanId channel id
  * @param {String} subId subscription
- * @param {Object} body document
+ * @param {Object} body channel message
  */
 const mes = (chanId, subId, body) => ({
   'evt-id': shortid(),

--- a/lib/events/server/mes.js
+++ b/lib/events/server/mes.js
@@ -8,7 +8,7 @@ const shortid = require('shortid')
  * @param {String} subId subscription
  * @param {Object} body channel message
  */
-const mes = (chanId, subId, body) => ({
+const mes = ({ chanId, subId, body }) => ({
   mes: {
     'evt-id': shortid(),
     'chan-id': chanId,

--- a/lib/events/server/mes.js
+++ b/lib/events/server/mes.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const shortid = require('shortid')
+
+/**
+ * Creates message event
+ * @param {String} chanId channel id
+ * @param {String} subId subscription
+ * @param {Object} body document
+ */
+const mes = (chanId, subId, body) => ({
+  'evt-id': shortid(),
+  'chan-id': chanId,
+  'sub-id': subId,
+  body,
+})
+
+module.exports = mes

--- a/lib/events/server/res.js
+++ b/lib/events/server/res.js
@@ -9,10 +9,12 @@ const shortid = require('shortid')
  * @param {Array} docs documents to be sent
  */
 const res = (colId, ftcId, docs) => ({
-  'evt-id': shortid(),
-  'col-id': colId,
-  'ftc-id': ftcId,
-  docs,
+  res: {
+    'evt-id': shortid(),
+    'col-id': colId,
+    'ftc-id': ftcId,
+    docs,
+  },
 })
 
 module.exports = res

--- a/lib/events/server/res.js
+++ b/lib/events/server/res.js
@@ -8,7 +8,7 @@ const shortid = require('shortid')
  * @param {String} ftcId fetch id
  * @param {Array} docs documents to be sent
  */
-const res = (colId, ftcId, docs) => ({
+const res = ({ colId, ftcId, docs }) => ({
   res: {
     'evt-id': shortid(),
     'col-id': colId,

--- a/lib/events/server/res.js
+++ b/lib/events/server/res.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const shortid = require('shortid')
+
+/**
+ * Create results event
+ * @param {String} colId collection id
+ * @param {String} ftcId fetch id
+ * @param {Array} docs documents to be sent
+ */
+const res = (colId, ftcId, docs) => ({
+  'evt-id': shortid(),
+  'col-id': colId,
+  'ftc-id': ftcId,
+  docs,
+})
+
+module.exports = res

--- a/lib/events/server/rm.js
+++ b/lib/events/server/rm.js
@@ -9,10 +9,12 @@ const shortid = require('shortid')
  * @param {id} id document id to be deleted
  */
 const rm = (colId, subId, id) => ({
-  'evt-id': shortid(),
-  'col-id': colId,
-  'sub-id': subId,
-  doc: { id },
+  rm: {
+    'evt-id': shortid(),
+    'col-id': colId,
+    'sub-id': subId,
+    doc: { id },
+  },
 })
 
 module.exports = rm

--- a/lib/events/server/rm.js
+++ b/lib/events/server/rm.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const shortid = require('shortid')
+
+/**
+ * Creates remove event
+ * @param {String} colId collection id
+ * @param {String} subId subscription id
+ * @param {id} id document id to be deleted
+ */
+const rm = (colId, subId, id) => ({
+  'evt-id': shortid(),
+  'col-id': colId,
+  'sub-id': subId,
+  doc: { id },
+})
+
+module.exports = rm

--- a/lib/events/server/rm.js
+++ b/lib/events/server/rm.js
@@ -8,12 +8,12 @@ const shortid = require('shortid')
  * @param {String} subId subscription id
  * @param {id} id document id to be deleted
  */
-const rm = (colId, subId, id) => ({
+const rm = ({ colId, subId, docId }) => ({
   rm: {
     'evt-id': shortid(),
     'col-id': colId,
     'sub-id': subId,
-    doc: { id },
+    doc: { docId },
   },
 })
 

--- a/lib/events/server/upd.js
+++ b/lib/events/server/upd.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const shortid = require('shortid')
+
+/**
+ * Creates update event
+ * @param {String} colId collection id
+ * @param {String} subId subscription id
+ * @param {Object} doc document
+ */
+const upd = (colId, subId, doc) => ({
+  'evt-id': shortid(),
+  'col-id': colId,
+  'sub-id': subId,
+  doc,
+})
+
+module.exports = upd

--- a/lib/events/server/upd.js
+++ b/lib/events/server/upd.js
@@ -9,10 +9,12 @@ const shortid = require('shortid')
  * @param {Object} doc document
  */
 const upd = (colId, subId, doc) => ({
-  'evt-id': shortid(),
-  'col-id': colId,
-  'sub-id': subId,
-  doc,
+  upd: {
+    'evt-id': shortid(),
+    'col-id': colId,
+    'sub-id': subId,
+    doc,
+  },
 })
 
 module.exports = upd

--- a/lib/events/server/upd.js
+++ b/lib/events/server/upd.js
@@ -8,7 +8,7 @@ const shortid = require('shortid')
  * @param {String} subId subscription id
  * @param {Object} doc document
  */
-const upd = (colId, subId, doc) => ({
+const upd = ({ colId, subId, doc }) => ({
   upd: {
     'evt-id': shortid(),
     'col-id': colId,

--- a/lib/events/server/val.js
+++ b/lib/events/server/val.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const shortid = require('shortid')
+
+/**
+ * Creates value event
+ * @param {String} colId collection id
+ * @param {String} subId subscription id
+ * @param {Array} docs documents to be sent
+ */
+const val = (colId, subId, docs) => ({
+  'evt-id': shortid(),
+  'col-id': colId,
+  'sub-id': subId,
+  docs,
+})
+
+module.exports = val

--- a/lib/events/server/val.js
+++ b/lib/events/server/val.js
@@ -9,10 +9,12 @@ const shortid = require('shortid')
  * @param {Array} docs documents to be sent
  */
 const val = (colId, subId, docs) => ({
-  'evt-id': shortid(),
-  'col-id': colId,
-  'sub-id': subId,
-  docs,
+  val: {
+    'evt-id': shortid(),
+    'col-id': colId,
+    'sub-id': subId,
+    docs,
+  },
 })
 
 module.exports = val

--- a/lib/events/server/val.js
+++ b/lib/events/server/val.js
@@ -8,7 +8,7 @@ const shortid = require('shortid')
  * @param {String} subId subscription id
  * @param {Array} docs documents to be sent
  */
-const val = (colId, subId, docs) => ({
+const val = ({ colId, subId, docs }) => ({
   val: {
     'evt-id': shortid(),
     'col-id': colId,

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,11 +3,15 @@
 const validation = require('./validation')
 const ack = require('./events/ack')
 const err = require('./events/err')
+const client = require('./events/client')
+const server = require('./events/server')
 const filter = require('./shared/filter')
 
 module.exports = {
   validate: validation,
   ack,
   err,
+  client,
+  server,
   filterSchema: filter,
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Protocol and validation for Rapid.io",
   "main": "./lib/index.js",
   "dependencies": {
-    "ajv": "^5.0.0"
+    "ajv": "^5.0.0",
+    "shortid": "^2.2.8"
   },
   "devDependencies": {
     "@strv/eslint-config-javascript": "^6.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,25 +28,19 @@ ajv-keywords@^1.0.0:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
 
 ajv@^4.7.0:
-  version "4.11.7"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.7.tgz#8655a5d86d0824985cc471a1d913fb6729a0ec48"
+  version "4.11.8"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
   dependencies:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 ajv@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.0.0.tgz#a2c717764e8036d15fd227b070ddaf7867ab413a"
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.1.5.tgz#8734931b601f00d4feef7c65738d77d1b65d1f68"
   dependencies:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-=======
->>>>>>> master
-=======
->>>>>>> master
 ansi-escapes@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
@@ -117,48 +111,44 @@ babel-runtime@^6.22.0:
     regenerator-runtime "^0.10.0"
 
 babel-traverse@^6.23.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.24.1.tgz#ab36673fd356f9a0948659e7b338d5feadb31695"
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.25.0.tgz#2257497e2fcd19b89edc13c4c91381f9512496f1"
   dependencies:
     babel-code-frame "^6.22.0"
     babel-messages "^6.23.0"
     babel-runtime "^6.22.0"
-    babel-types "^6.24.1"
-    babylon "^6.15.0"
+    babel-types "^6.25.0"
+    babylon "^6.17.2"
     debug "^2.2.0"
     globals "^9.0.0"
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.23.0, babel-types@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.24.1.tgz#a136879dc15b3606bda0d90c1fc74304c2ff0975"
+babel-types@^6.23.0, babel-types@^6.25.0:
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.25.0.tgz#70afb248d5660e5d18f811d91c8303b54134a18e"
   dependencies:
     babel-runtime "^6.22.0"
     esutils "^2.0.2"
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babylon@^6.15.0, babylon@^6.17.0:
-  version "6.17.0"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.0.tgz#37da948878488b9c4e3c4038893fa3314b3fc932"
+babylon@^6.17.0, babylon@^6.17.2:
+  version "6.17.3"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.3.tgz#1327d709950b558f204e5352587fd0290f8d8e48"
 
-balanced-match@^0.4.1:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
+balanced-match@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
-brace-expansion@^1.0.0:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.7.tgz#3effc3c50e000531fb720eaff80f0ae8ef23cf59"
+brace-expansion@^1.1.7:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
   dependencies:
-    balanced-match "^0.4.1"
+    balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-buffer-shims@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
-
-builtin-modules@^1.1.1:
+builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
@@ -241,10 +231,10 @@ debug@2.2.0:
     ms "0.7.1"
 
 debug@^2.1.1, debug@^2.2.0:
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.4.tgz#7586a9b3c39741c0282ae33445c4e8ac74734fe0"
+  version "2.6.8"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
-    ms "0.7.3"
+    ms "2.0.0"
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -283,6 +273,12 @@ doctrine@^2.0.0:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
+error-ex@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
+  dependencies:
+    is-arrayish "^0.2.1"
+
 es-abstract@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.7.0.tgz#dfade774e01bfcd97f96180298c449c8623fb94c"
@@ -301,8 +297,8 @@ es-to-primitive@^1.1.1:
     is-symbol "^1.0.1"
 
 es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
-  version "0.10.15"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.15.tgz#c330a5934c1ee21284a7c081a86e5fd937c91ea6"
+  version "0.10.23"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.23.tgz#7578b51be974207a5487821b56538c224e4e7b38"
   dependencies:
     es6-iterator "2"
     es6-symbol "~3.1"
@@ -381,8 +377,8 @@ eslint-module-utils@^2.0.0:
     pkg-dir "^1.0.0"
 
 eslint-plugin-import@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.2.0.tgz#72ba306fad305d67c4816348a4699a4229ac8b4e"
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.3.0.tgz#37c801e0ada0e296cbdf20c3f393acb5b52af36b"
   dependencies:
     builtin-modules "^1.1.1"
     contains-path "^0.1.0"
@@ -393,7 +389,7 @@ eslint-plugin-import@^2.2.0:
     has "^1.0.1"
     lodash.cond "^4.3.0"
     minimatch "^3.0.3"
-    pkg-up "^1.0.0"
+    read-pkg-up "^2.0.0"
 
 eslint-plugin-react@^6.10.0:
   version "6.10.3"
@@ -446,8 +442,8 @@ eslint@^3.13.1:
     user-home "^2.0.0"
 
 espree@^3.4.0:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.2.tgz#38dbdedbedc95b8961a1fbf04734a8f6a9c8c592"
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.3.tgz#2910b5ccd49ce893c2ffffaab4fd8b3a31b82374"
   dependencies:
     acorn "^5.0.1"
     acorn-jsx "^3.0.0"
@@ -517,6 +513,12 @@ find-up@^1.0.0:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
 
+find-up@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
+  dependencies:
+    locate-path "^2.0.0"
+
 flat-cache@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.2.2.tgz#fa86714e72c21db88601761ecf2f555d1abc6b96"
@@ -549,19 +551,19 @@ generate-object-property@^1.1.0:
     is-property "^1.0.0"
 
 glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
     inherits "2"
-    minimatch "^3.0.2"
+    minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
 globals@^9.0.0, globals@^9.14.0:
-  version "9.17.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-9.17.0.tgz#0c0ca696d9b9bb694d2e5470bd37777caad50286"
+  version "9.18.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
 globby@^5.0.0:
   version "5.0.0"
@@ -590,9 +592,13 @@ has@^1.0.1:
   dependencies:
     function-bind "^1.0.2"
 
+hosted-git-info@^2.1.4:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.4.2.tgz#0076b9f46a270506ddbaaea56496897460612a67"
+
 ignore@^3.2.0:
-  version "3.2.7"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.2.7.tgz#4810ca5f1d8eca5595213a34b94f2eb4ed926bbd"
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.3.tgz#432352e57accd87ab3110e82d3fea0e47812156d"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -636,6 +642,16 @@ invariant@^2.2.0:
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
     loose-envify "^1.0.0"
+
+is-arrayish@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
+
+is-builtin-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe"
+  dependencies:
+    builtin-modules "^1.0.0"
 
 is-callable@^1.1.1, is-callable@^1.1.3:
   version "1.1.3"
@@ -709,8 +725,8 @@ js-tokens@^3.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
 js-yaml@^3.5.1:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.3.tgz#33a05ec481c850c8875929166fe1beb61c728766"
+  version "3.8.4"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.4.tgz#520b4564f86573ba96662af85a8cafa7b4b5a6f6"
   dependencies:
     argparse "^1.0.7"
     esprima "^3.1.1"
@@ -729,22 +745,6 @@ jsonpointer@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
->>>>>>> master
-jsonschema@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.1.1.tgz#3cede8e3e411d377872eefbc9fdf26383cbc3ed9"
-
-<<<<<<< HEAD
->>>>>>> master
-=======
->>>>>>> b497366... Resolve merge conflict
-=======
->>>>>>> master
 jsx-ast-utils@^1.3.4:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz#3867213e8dd79bf1e8f2300c0cfc1efb182c0df1"
@@ -755,6 +755,22 @@ levn@^0.3.0, levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+load-json-file@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^2.2.0"
+    pify "^2.0.0"
+    strip-bom "^3.0.0"
+
+locate-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
+  dependencies:
+    p-locate "^2.0.0"
+    path-exists "^3.0.0"
 
 lodash.cond@^4.3.0:
   version "4.5.2"
@@ -770,11 +786,11 @@ loose-envify@^1.0.0:
   dependencies:
     js-tokens "^3.0.0"
 
-minimatch@^3.0.2, minimatch@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
+minimatch@^3.0.3, minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
-    brace-expansion "^1.0.0"
+    brace-expansion "^1.1.7"
 
 minimist@0.0.8:
   version "0.0.8"
@@ -790,9 +806,9 @@ ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
 
-ms@0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.3.tgz#708155a5e44e33f5fd0fc53e81d0d40a91be1fff"
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
 mute-stream@0.0.5:
   version "0.0.5"
@@ -801,6 +817,15 @@ mute-stream@0.0.5:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+normalize-package-data@^2.3.2:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.3.8.tgz#d819eda2a9dedbd1ffa563ea4071d936782295bb"
+  dependencies:
+    hosted-git-info "^2.1.4"
+    is-builtin-module "^1.0.0"
+    semver "2 || 3 || 4 || 5"
+    validate-npm-package-license "^3.0.1"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -847,11 +872,31 @@ os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
+p-limit@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.1.0.tgz#b07ff2d9a5d88bec806035895a2bab66a27988bc"
+
+p-locate@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
+  dependencies:
+    p-limit "^1.1.0"
+
+parse-json@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
+  dependencies:
+    error-ex "^1.2.0"
+
 path-exists@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
   dependencies:
     pinkie-promise "^2.0.0"
+
+path-exists@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -864,6 +909,12 @@ path-is-inside@^1.0.1:
 path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
+path-type@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
+  dependencies:
+    pify "^2.0.0"
 
 pify@^2.0.0:
   version "2.3.0"
@@ -885,12 +936,6 @@ pkg-dir@^1.0.0:
   dependencies:
     find-up "^1.0.0"
 
-pkg-up@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-1.0.0.tgz#3e08fb461525c4421624a33b9f7e6d0af5b05a26"
-  dependencies:
-    find-up "^1.0.0"
-
 pluralize@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
@@ -907,15 +952,30 @@ progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
 
-readable-stream@^2.2.2:
-  version "2.2.9"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.9.tgz#cf78ec6f4a6d1eb43d26488cac97f042e74b7fc8"
+read-pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
   dependencies:
-    buffer-shims "~1.0.0"
+    find-up "^2.0.0"
+    read-pkg "^2.0.0"
+
+read-pkg@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-2.0.0.tgz#8ef1c0623c6a6db0dc6713c4bfac46332b2368f8"
+  dependencies:
+    load-json-file "^2.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^2.0.0"
+
+readable-stream@^2.2.2:
+  version "2.2.11"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.11.tgz#0796b31f8d7688007ff0b93a8088d34aa17c0f72"
+  dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.1"
     isarray "~1.0.0"
     process-nextick-args "~1.0.6"
+    safe-buffer "~5.0.1"
     string_decoder "~1.0.0"
     util-deprecate "~1.0.1"
 
@@ -934,8 +994,8 @@ rechoir@^0.6.2:
     resolve "^1.1.6"
 
 regenerator-runtime@^0.10.0:
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.3.tgz#8c4367a904b51ea62a908ac310bf99ff90a82a3e"
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
 require-uncached@^1.0.2:
   version "1.0.3"
@@ -977,17 +1037,43 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
+safe-buffer@~5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
+
+"semver@2 || 3 || 4 || 5":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+
 shelljs@^0.7.5:
-  version "0.7.7"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.7.tgz#b2f5c77ef97148f4b4f6e22682e10bba8667cff1"
+  version "0.7.8"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
+shortid@^2.2.8:
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.8.tgz#033b117d6a2e975804f6f0969dbe7d3d0b355131"
+
 slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
+
+spdx-correct@~1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-1.0.2.tgz#4b3073d933ff51f3912f03ac5519498a4150db40"
+  dependencies:
+    spdx-license-ids "^1.0.2"
+
+spdx-expression-parse@~1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz#9bdf2f20e1f40ed447fbe273266191fced51626c"
+
+spdx-license-ids@^1.0.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -1009,10 +1095,10 @@ string-width@^2.0.0:
     strip-ansi "^3.0.0"
 
 string_decoder@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.0.tgz#f06f41157b664d86069f84bdbdc9b0d8ab281667"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.2.tgz#b29e1f4e1125fa97a10382b8a533737b7491e179"
   dependencies:
-    buffer-shims "~1.0.0"
+    safe-buffer "~5.0.1"
 
 strip-ansi@^3.0.0:
   version "3.0.1"
@@ -1052,8 +1138,8 @@ through@^2.3.6:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
 to-fast-properties@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.2.tgz#f3f5c0c3ba7299a7ef99427e44633257ade43320"
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 
 tryit@^1.0.1:
   version "1.0.3"
@@ -1078,6 +1164,13 @@ user-home@^2.0.0:
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+
+validate-npm-package-license@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz#2804babe712ad3379459acfbe24746ab2c303fbc"
+  dependencies:
+    spdx-correct "~1.0.0"
+    spdx-expression-parse "~1.0.0"
 
 wordwrap@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Added all client and server events from a protocol.

You can import them as: 
`const { client } = require('@rapid.io/protocol')`
or
`const { server } = require('@rapid.io/protocol')`.

Common events `ack` and `err` are still top-level exports.
`const  { ack } from '@rapid.io/protocol'`

Unification of the event source should help keeping consistency between SDK's and server. Also it should make easier to add new events and help writing tests.

/cc @schwarja 